### PR TITLE
Added templating support to the URL command

### DIFF
--- a/api.php
+++ b/api.php
@@ -269,20 +269,26 @@ function storeCustomer($config = [], $data = [])
  * @param array $data command data
  * @return string
  */
-function buildMessage($paymentData = [], $data = [])
+function buildMessage($paymentData = [], $data = [], $url_encode = false)
 {
+    $replacement_values = [
+        $paymentData['formatted_amount'],
+        runningTotal('everything'),
+        runningTotal('today'),
+        runningTotal('this_month')
+    ];
+
+    if ($url_encode) {
+        $replacement_values = array_map('urlencode', $replacement_values);
+    }
+
     // Find and replace values in array as payment details
     $text = str_replace([
         '{{AMOUNT}}',
         '{{EVERYTHING}}',
         '{{TODAY}}',
         '{{THIS_MONTH}}'
-    ], [
-        $paymentData['formatted_amount'],
-        runningTotal('everything'),
-        runningTotal('today'),
-        runningTotal('this_month')
-    ], is_array($data) ? end($data) : $data);
+    ],  $replacement_values, is_array($data) ? end($data) : $data);
 
     custom_logs('Build Message Output: ' . $text);
     return $text;
@@ -314,7 +320,7 @@ function runCommand($data = [])
         custom_logs("Is URL");
         $updated_url = buildMessage([
             'formatted_amount' => $data['formatted_amount']
-        ], $command_args[0]);
+        ], $command_args[0], true);
         $command_args[0] = $updated_url;
 
         $updated_post_body = buildMessage([

--- a/api.php
+++ b/api.php
@@ -310,6 +310,27 @@ function runCommand($data = [])
         array_pop($command_args);
         $command_args[] = $text;
     }
+    else if ($data['command'] == 'URL') {
+        custom_logs("Is URL");
+        $updated_url = buildMessage([
+            'formatted_amount' => $data['formatted_amount']
+        ], $command_args[0]);
+        $command_args[0] = $updated_url;
+
+        $updated_post_body = buildMessage([
+            'formatted_amount' => $data['formatted_amount']
+        ], $command_args[2]);
+        $command_args[2] = $updated_post_body;
+    }
+
+    if ($data['command'] != 'Overlay Model Effect') {
+        // Write command args back into $data, but only for commands other than Overlay Model Effect,
+        // which never used to do it - is this a bug that needs fixing?
+        $data['args'] = $command_args;
+    }
+
+    custom_logs('Sending command: ' . $data);
+
     // Fire the command
     $query = json_encode($data);
     $ch    = curl_init();

--- a/zettle.common.php
+++ b/zettle.common.php
@@ -131,7 +131,7 @@
 
   function runningTotal($option = 'everything')
   {
-    return file_get_contents('http://localhost/plugin.php?plugin=fpp-zettle&page=zettle.php&command=get_purchases&nopage=1&option=' . $option);
+    return trim(file_get_contents('http://localhost/plugin.php?plugin=fpp-zettle&page=zettle.php&command=get_purchases&nopage=1&option=' . $option));
   }
 
   function isSiteAvailible($url)


### PR DESCRIPTION
With this I'm able to parameterise the URL command.
Setting Post Data to:
`{"amount":"{{AMOUNT}}","everything":"{{EVERYTHING}}","today":"{{TODAY}}","this_month":"{{THIS_MONTH}}"}`,

yields this request body:
`{"amount":"1.00 GBP","everything":"£15.00","today":"£13.00","this_month":"£13.00"}`

I've also stripped whitespace from the totals, as they included a few spaces and a tab.

A few notes:
* We should document this templating behaviour in the setup UI
* There are likely other commands that could benefit (eg MQTT, but I'm not sure how to have the data come through as a proper object, rather than a single string)
* There seems to be a bug with the Overlay Model Effect's templating - `$command_args` is copied out of `$data['args']` by value, so it doesn't actually get updated for `$query`. I've added a general solution for all other commands, retaining the bug for Overlay Model Effect in-case the behaviour is being relied on.

#6 